### PR TITLE
Fix compilation error on nightly Rust

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,5 +1,4 @@
-#![cfg_attr(nightly, feature(external_doc))]
-#![cfg_attr(nightly, doc(include = "../README.md"))]
+#![doc(include = "../README.md")]
 
 extern crate serde;
 


### PR DESCRIPTION
There is no longer an `external_doc` feature as it has been stabilized so I've removed the feature so it compiles on nightly Rust